### PR TITLE
Simplify and refine where possible

### DIFF
--- a/docs/components/Shell/Footer.js
+++ b/docs/components/Shell/Footer.js
@@ -28,6 +28,11 @@ export function Footer() {
             position: relative;
             z-index: 100;
           }
+
+          // brand
+          .footer :global(a) {
+            font-size: 0.85rem;
+          }
         `}
       </style>
     </div>

--- a/docs/components/Shell/Header.js
+++ b/docs/components/Shell/Header.js
@@ -7,7 +7,7 @@ export function Header() {
     <div className="nav-bar">
       <nav>
         <Link href="/" className="brand">
-          TS Runtime DX&nbsp;Test
+          TS Runtime DX
         </Link>
         <ul>
           <li>

--- a/docs/components/Shell/Header.js
+++ b/docs/components/Shell/Header.js
@@ -7,14 +7,14 @@ export function Header() {
     <div className="nav-bar">
       <nav>
         <Link href="/" className="brand">
-          TS Runtime DX
+          TS Runtime DX&nbsp;Test
         </Link>
         <ul>
           <li>
             <Link href="/docs/getting-started">Docs</Link>
           </li>
           <li>
-            <Link href="https://github.com/thinkmill/ts-runtime-dx">GitHub</Link>
+            <Link href="https://github.com/thinkmill/ts-runtime-dx">GitHub &rarr;</Link>
           </li>
         </ul>
       </nav>
@@ -55,6 +55,12 @@ export function Header() {
           }
           li {
             margin: 0;
+          }
+          @media screen and (min-width: 1001px) {
+            ul {
+              flex: 0 0 var(--sidenav-width);
+              padding-left: 1.5rem;
+            }
           }
         `}
       </style>

--- a/docs/components/Shell/SideNav.js
+++ b/docs/components/Shell/SideNav.js
@@ -22,40 +22,50 @@ const items = [
   },
 ];
 
+function getGroupHeadingId(str) {
+  return 'group-section-' + str.replace(/\s+/g, '-').toLowerCase();
+}
+
 export function SideNav() {
   const router = useRouter();
 
   return (
-    <nav className="sidenav">
-      {items.map(item => (
-        <div key={item.title}>
-          <h3>{item.title}</h3>
-          <ul className="flex column">
-            {item.links.map(link => {
-              const active = router.pathname === link.href;
-              return (
-                <li key={link.href} className={active ? 'active' : ''}>
-                  <Link {...link}>
-                    <a href={link.href}>{link.children}</a>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ))}
+    <nav className="sidenav" aria-label="docs navigation">
+      {items.map(item => {
+        const groupHeadingId = getGroupHeadingId(item.title);
+
+        return (
+          <nav className="groupnav" key={item.title} aria-labelledby={groupHeadingId}>
+            <h3 id={groupHeadingId}>{item.title}</h3>
+            <ul className="flex column">
+              {item.links.map(link => {
+                const active = router.pathname === link.href;
+                return (
+                  <li key={link.href} className={active ? 'active' : ''}>
+                    <Link {...link}>
+                      <a href={link.href}>{link.children}</a>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+        );
+      })}
       <style jsx>
         {`
-          nav {
+          .sidenav {
             /* https://stackoverflow.com/questions/66898327/how-to-keep-footer-from-pushing-up-sticky-sidebar */
             position: sticky;
             top: var(--header-height);
-            height: calc(100vh - (var(--header-height) + var(--footer-height)));
+            height: calc(100vh - var(--header-height) - var(--footer-height));
+            margin-bottom: calc(var(--footer-height) * -1);
             flex: 0 0 var(--sidenav-width);
             overflow-y: auto;
             padding: 2rem 0 2rem 2rem;
           }
           h3 {
+            color: var(--text-prominent);
             font-weight: 500;
             font-size: 1rem;
             margin: 0.5rem 0 0;
@@ -63,24 +73,28 @@ export function SideNav() {
           }
           ul {
             font-size: 0.85rem;
-            margin: 0;
+            margin: 0 0 2em;
             padding: 0;
           }
           li {
+            border-left: 1px solid var(--border);
             list-style-type: none;
             margin: 0;
+            padding: 0.25rem 0;
           }
           li a {
             display: block;
             font-weight: 400;
             text-decoration: none;
-            padding: 0.35rem 0 0.35rem 0.7rem;
+            padding: 0.25rem 0.5rem 0.25rem 1rem;
           }
           li a:hover {
             text-decoration: underline;
           }
           li.active > a {
-            color: var(--blue);
+            // border-left-color: var(--text-prominent);
+            box-shadow: -1px 0 var(--text-prominent);
+            color: var(--text-prominent);
             font-weight: 500;
           }
           @media screen and (max-width: 600px) {

--- a/docs/components/Shell/TableOfContents.js
+++ b/docs/components/Shell/TableOfContents.js
@@ -2,11 +2,14 @@ import React from 'react';
 import Link from 'next/link';
 
 export function TableOfContents({ toc }) {
+  const headingId = 'toc-heading';
   const items = toc.filter(
     item => item.id && (item.level === 2 || item.level === 3) && item.title !== 'Next steps',
   );
+
   return (
     <nav className="toc">
+      <h3 id={headingId}>On this page</h3>
       {items.length > 1 ? (
         <ul className="flex column">
           {items.map(item => {
@@ -38,7 +41,15 @@ export function TableOfContents({ toc }) {
             align-self: flex-start;
             margin-bottom: 1rem;
             padding: 0.25rem 0 0;
-            border-left: 1px solid var(--border);
+            // border-left: 1px solid var(--border);
+          }
+          h3 {
+            color: var(--text-prominent);
+            font-weight: 500;
+            font-size: 1rem;
+            margin: 0;
+            padding-bottom: 0.75rem;
+            padding-left: 1.5rem;
           }
           ul {
             margin: 0;

--- a/docs/markdoc/nodes/heading.markdoc.js
+++ b/docs/markdoc/nodes/heading.markdoc.js
@@ -6,10 +6,12 @@ function generateID(children, attributes) {
     return attributes.id;
   }
   return children
-    .filter((child) => typeof child === 'string')
+    .filter(child => typeof child === 'string')
     .join(' ')
     .replace(/[?]/g, '')
+    .replace(/[A-Z]/g, s => '-' + s)
     .replace(/\s+/g, '-')
+    .replace(/^-/, '')
     .toLowerCase();
 }
 
@@ -19,7 +21,7 @@ export default {
   attributes: {
     id: { type: String },
     level: { type: Number, required: true, default: 1 },
-    className: { type: String }
+    className: { type: String },
   },
   transform(node, config) {
     const attributes = node.transformAttributes(config);
@@ -27,5 +29,5 @@ export default {
     const id = generateID(children, attributes);
 
     return new Tag(this.render, { ...attributes, id }, children);
-  }
+  },
 };

--- a/docs/pages/docs/assertions.md
+++ b/docs/pages/docs/assertions.md
@@ -75,6 +75,11 @@ function doThing(type: 'draft' | 'published') {
 Regardless of the condition, this function **always** throws.
 {% /callout %}
 
+```ts
+doThing('archived');
+// → Error: Unexpected call to assertNever: 'archived'
+```
+
 ## Debugging
 
 In **development** both `assert` and `assertNever` will include a [debugger statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger), which will pause execution to aid debugging.

--- a/docs/pages/docs/assertions.md
+++ b/docs/pages/docs/assertions.md
@@ -5,10 +5,10 @@ description: Functions for asserting the "truthiness" of a condition
 
 # {% $markdoc.frontmatter.title %}
 
-An assertion declares that a condition be ["truthy"](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) before executing subsequent code.
+An assertion declares that a condition be `true` before executing subsequent code.
 
-- If the condition evaluates to `true` the code continues running.
-- If the condition evaluates to `false` an error will be thrown.
+- If the condition resolves to `true` the code continues running.
+- If the condition resolves to `false` an error will be thrown.
 
 ## Functions
 
@@ -16,10 +16,10 @@ TypeScript supports the `asserts` keyword, for use in the return statement of [a
 
 ### assert
 
-Asserts that a condition is "truthy", ensuring that whatever condition is being checked must be true for the remainder of the containing scope.
+Asserts that a condition is `true`, ensuring that whatever condition is being checked must be true for the remainder of the containing scope.
 
 ```ts
-function assert(condition: any, message?: string): asserts condition;
+function assert(condition: boolean, message?: string): asserts condition;
 ```
 
 The `assert` function has a default message:
@@ -37,13 +37,19 @@ assert(falsyValue >= 0, `Expected a non-negative number, but received: ${falsyVa
 // → TypeError: Expected a non-negative number, but received: -1
 ```
 
+#### Condition type
+
+{% callout %}
+The narrow type of `boolean` is an intentional design decision.
+{% /callout %}
+
+Other assertion functions may accept ["truthy"](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) and ["falsy"](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) conditions, while `assert` only accepts conditions that resolve to `boolean`.
+
+The goal is to promote consideration from consumers when dealing with potentially ambiguous values like `0` or `''`, which can introduce subtle bugs.
+
 ### assertNever
 
 Asserts that allegedly unreachable code has been executed.
-
-{% callout %}
-When called, this function will always throw.
-{% /callout %}
 
 ```ts
 function assertNever(condition: never): never;
@@ -52,13 +58,11 @@ function assertNever(condition: never): never;
 Use `assertNever` to catch logic forks that shouldn't be possible.
 
 ```ts
-function doThing(type: 'draft' | 'published' | 'archived') {
+function doThing(type: 'draft' | 'published') {
   switch (type) {
     case 'draft':
       return; /*...*/
     case 'published':
-      return; /*...*/
-    case 'archived':
       return; /*...*/
 
     default:
@@ -66,6 +70,10 @@ function doThing(type: 'draft' | 'published' | 'archived') {
   }
 }
 ```
+
+{% callout type="warning" %}
+Regardless of the condition, this function **always** throws.
+{% /callout %}
 
 ## Debugging
 

--- a/docs/pages/docs/guards.md
+++ b/docs/pages/docs/guards.md
@@ -96,5 +96,5 @@ Guards for [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 Checks whether an array is **not** empty.
 
 ```ts
-function isNonEmptyArray<T>(arr: T[]): arr is [T, ...T[]];
+function isNonEmptyArray<T>(value: T[]): value is [T, ...T[]];
 ```

--- a/docs/pages/docs/origin-story.md
+++ b/docs/pages/docs/origin-story.md
@@ -16,7 +16,7 @@ The discussion that followed confirmed a desire for an approach to TypeScript de
 To express our intent we often write types that are technically accurate but leave consumers scratching their heads when something goes wrong. Consider this component definition:
 
 {% callout %}
-React is used in these [examples](https://www.typescriptlang.org/play?jsx=4&noErrorTruncation=false#code/JYWwDg9gTgLgBAcigUwIYGMYHoBWBnADwFooBXAOxlGQQG4BYAKCZgE8xk4AZVAI2QA2ABSgQweOAF44Ab0SoowVEQF9BCAFxw8MReQDmAGnmLlq-gIHIAJr1YIA-FvLIAbsihwAvnAA+skyUVNQFHZzcPWkCzEKtbey0dPX1vFnZOABUAC2ADETEJaTkIGCyPRN1clJ8AMm4Q-PEmJnQIch04bKqpOAAKMFFxLS68wbwASikAPlkmODgUGFIocjgAHmtgV1kAOj2Bgp8sKaYvZsZkAkhYOFb2+ABRAlRwKwB5EGA8PGA2nt7JpIZjI5gtkEsVusRikSmUoJIAEQAdSyqBgESgCLgx1O5ywWDgl2u8DuHSeLzAVgAwhAQLxcmjfqtpADprNGPj5mCIas1tC4LCPIiUWiMViFEFzIJEU9KcB0MB4FKBOLTMELHE7Ii8LTkERgNYsTiOQSzowgA), but ts-runtime-dx is framework agnostic
+React is used in these examples, but ts-runtime-dx is framework agnostic
 {% /callout %}
 
 ```tsx
@@ -25,7 +25,9 @@ type LabelProps =
   | { 'aria-label'?: never; 'aria-labelledby': string };
 type ThingProps = { other: string } & LabelProps;
 
-const Thing = (props: ThingProps) => /* omitted for brevity */
+const Thing = (props: ThingProps) => {
+  return; /* omitted for brevity */
+};
 ```
 
 ### TypeScript errors (buildtime)

--- a/docs/public/global.css
+++ b/docs/public/global.css
@@ -146,6 +146,11 @@ a:hover {
   text-decoration-thickness: 2px;
 }
 
+/* Indicate external links */
+article a[href^='http'] {
+  color: var(--blue);
+}
+
 button {
   cursor: pointer;
   appearance: none;
@@ -377,6 +382,7 @@ pre > code {
 
 .code-block {
   margin: 0 0 var(--default-vertical-spacing);
+  margin: 0.25rem 0 1rem;
   position: relative;
 }
 .code-block button {

--- a/src/assertions.test.ts
+++ b/src/assertions.test.ts
@@ -3,27 +3,25 @@ import { getErrorMessage } from './utils/error';
 
 describe('assertions', () => {
   describe('assert', () => {
-    it('should throw when the condition is "falsy"', () => {
+    it('should throw when the condition is `false`', () => {
       expect(() => assert(false)).toThrow();
-      expect(() => assert(+0)).toThrow();
-      expect(() => assert(-0)).toThrow();
-      expect(() => assert('')).toThrow();
-      expect(() => assert(null)).toThrow();
-      expect(() => assert(undefined)).toThrow();
-      expect(() => assert(NaN)).toThrow();
     });
-    it('should not throw when the condition is "truthy"', () => {
-      const mockFn = jest.fn();
-
+    it('should not throw when the condition is `true`', () => {
       expect(() => assert(true)).not.toThrow();
-      expect(() => assert(1)).not.toThrow();
-      expect(() => assert(-1)).not.toThrow();
-      expect(() => assert('test')).not.toThrow();
-      expect(() => assert({})).not.toThrow();
-      expect(() => assert([])).not.toThrow();
+    });
 
-      expect(() => assert(mockFn)).not.toThrow();
-      expect(mockFn).toBeCalledTimes(0);
+    it('should expect TS error when called with non-boolean conditions', () => {
+      const falsyValues = [0, -0, '', null, undefined, NaN];
+      const truthyValues = [1, -1, 'test', {}, [], Number.POSITIVE_INFINITY];
+
+      falsyValues.forEach(val => {
+        // @ts-expect-error should not accept non-boolean conditions
+        expect(() => assert(val)).toThrow();
+      });
+      truthyValues.forEach(val => {
+        // @ts-expect-error should not accept non-boolean conditions
+        expect(() => assert(val)).not.toThrow();
+      });
     });
 
     it('should throw a TypeError with the "default" message, when none provided', () => {
@@ -41,6 +39,7 @@ describe('assertions', () => {
       }
     });
   });
+
   describe('assertNever', () => {
     it('should always throw', () => {
       // @ts-expect-error: for testing
@@ -59,8 +58,7 @@ describe('assertions', () => {
         // @ts-expect-error: for testing
         assertNever(value);
       } catch (error) {
-        assert(error instanceof Error);
-        expect(error.message).toBe(`Unexpected call to assertNever: ${value}`);
+        expect(getErrorMessage(error)).toBe(`Unexpected call to assertNever: ${value}`);
       }
     });
   });

--- a/src/assertions.test.ts
+++ b/src/assertions.test.ts
@@ -58,7 +58,7 @@ describe('assertions', () => {
         // @ts-expect-error: for testing
         assertNever(value);
       } catch (error) {
-        expect(getErrorMessage(error)).toBe(`Unexpected call to assertNever: ${value}`);
+        expect(getErrorMessage(error)).toBe(`Unexpected call to assertNever: '${value}'`);
       }
     });
   });

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -24,7 +24,7 @@ export function assert(condition: boolean, message = 'Assert failed'): asserts c
  */
 export function assertNever(condition: never): never {
   developmentDebugger();
-  throw new Error(`Unexpected call to assertNever: ${condition}`);
+  throw new Error(`Unexpected call to assertNever: '${condition}'`);
 }
 
 /** Pause execution in development to aid debugging. */

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -1,10 +1,15 @@
 /**
- * Asserts that a condition is ["truthy"](https://developer.mozilla.org/en-US/docs/Glossary/Truthy).
+ * Asserts that a condition is `true`, ensuring that whatever condition is being
+ * checked must be true for the remainder of the containing scope.
  *
- * @throws when given a ["falsy"](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) condition.
+ * @throws when the condition is `false`
+ * @returns void
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function assert(condition: any, message = 'Assert failed'): asserts condition {
+// NOTE: The narrow type of `boolean` instead of something like `unknown` is an
+// intentional design decision. The goal is to promote consideration from
+// consumers when dealing with potentially ambiguous conditions like `0` or
+// `''`, which can introduce "subtle" bugs.
+export function assert(condition: boolean, message = 'Assert failed'): asserts condition {
   if (!condition) {
     developmentDebugger();
     throw new TypeError(message);
@@ -14,7 +19,8 @@ export function assert(condition: any, message = 'Assert failed'): asserts condi
 /**
  * Asserts that allegedly unreachable code has been executed.
  *
- * @throws always.
+ * @throws always
+ * @returns void
  */
 export function assertNever(condition: never): never {
   developmentDebugger();

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -79,7 +79,6 @@ describe('guards', () => {
     it('isDefined should validate assumed values', () => {
       expect(isDefined(null)).toBe(false);
       expect(isDefined(undefined)).toBe(false);
-      expect(isDefined(NaN)).toBe(false);
 
       getValuesByTypeWithout(['null', 'undefined']).forEach(val => {
         expect(isDefined(val)).toBe(true);

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -45,6 +45,6 @@ export function isNullish(value: unknown): value is Nullish {
 }
 
 /** Checks whether a value is defined */
-export function isDefined<T>(value: T | Nullish): value is NonNullable<T> {
-  return !isNullish(value) && !Number.isNaN(value);
+export function isDefined<T>(value: T): value is NonNullable<T> {
+  return !isNullish(value);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export {
   isUndefined,
 } from './guards';
 
-export { toOpaque, toTransparent } from './opaques';
+export { castToOpaque } from './opaques';
 
 export { getErrorMessage } from './utils/error';
 export { typedEntries, typedKeys } from './utils/object';
@@ -34,11 +34,4 @@ export { typedEntries, typedKeys } from './utils/object';
 // Types
 // ------------------------------
 
-export type {
-  GuardedPredicate,
-  Nullish,
-  Opaque,
-  Predicate,
-  Transparent,
-  UnaryPredicate,
-} from './types';
+export type { Nullish, Opaque, UnaryPredicate } from './types';

--- a/src/opaques.test.ts
+++ b/src/opaques.test.ts
@@ -1,24 +1,25 @@
-import { toOpaque, toTransparent } from './opaques';
+import { castToOpaque } from './opaques';
 import { Opaque } from './types';
 
-type OpaqueString = Opaque<string, 'OpaqueString'>;
-type OpaqueNumber = Opaque<number, 'OpaqueNumber'>;
-type OpaqueBigInt = Opaque<bigint, 'OpaqueBigInt'>;
-type OpaqueSymbol = Opaque<symbol, 'OpaqueSymbol'>;
-
 describe('opaques', () => {
-  const opaqueString = toOpaque<OpaqueString>('string');
-  const opaqueNumber = toOpaque<OpaqueNumber>(1);
-  const opaqueBigInt = toOpaque<OpaqueBigInt>(BigInt(1));
-  const opaqueSymbol = toOpaque<OpaqueSymbol>(Symbol('symbol'));
+  describe('castToOpaque', () => {
+    it('should be equivalent to an identity function at runtime', () => {
+      type OpaqueString = Opaque<string, 'OpaqueString'>;
+      type OpaqueNumber = Opaque<number, 'OpaqueNumber'>;
+      type OpaqueBigInt = Opaque<bigint, 'OpaqueBigInt'>;
+      type OpaqueSymbol = Opaque<symbol, 'OpaqueSymbol'>;
 
-  describe('toOpaque', () => {
-    it('should be equivalent to an identity function', () => {
+      const opaqueString = castToOpaque<OpaqueString>('string');
+      const opaqueNumber = castToOpaque<OpaqueNumber>(1);
+      const opaqueBigInt = castToOpaque<OpaqueBigInt>(BigInt(1));
+      const opaqueSymbol = castToOpaque<OpaqueSymbol>(Symbol('symbol'));
+
       expect(opaqueString).toBe('string');
       expect(opaqueNumber).toBe(1);
       expect(opaqueBigInt).toBe(BigInt(1));
       expect(opaqueSymbol.toString()).toBe(Symbol('symbol').toString());
     });
+
     it('should expect TS error when Token parameter omitted', () => {
       // @ts-expect-error the second parameter `Token` is required
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -31,20 +32,7 @@ describe('opaques', () => {
     });
     it('should expect TS error when called without explicit type', () => {
       // @ts-expect-error must be called with an explicit type
-      toOpaque('string');
-    });
-  });
-
-  describe('toTransparent', () => {
-    it('should be equivalent to an identity function', () => {
-      expect(toTransparent(opaqueString)).toBe('string');
-      expect(toTransparent(opaqueNumber)).toBe(1);
-      expect(toTransparent(opaqueBigInt)).toBe(BigInt(1));
-      expect(toTransparent(opaqueSymbol).toString()).toBe(Symbol('symbol').toString());
-    });
-    it('should expect TS error when called with non-opaque type', () => {
-      // @ts-expect-error only useful when called with opaque type
-      toTransparent('string');
+      castToOpaque('string');
     });
   });
 });

--- a/src/opaques.ts
+++ b/src/opaques.ts
@@ -4,18 +4,13 @@ import { Opaque, Transparent, ValidOpaqueValues } from './types';
  * A generic helper function that takes a primitive value, and returns the value
  * after casting it to the provided opaque type.
  */
-export function toOpaque<OpaqueType extends Opaque<ValidOpaqueValues, unknown> = never>(
-  value: Transparent<OpaqueType>,
-) {
+// 1. extend `Opaque` to exclude transparent types e.g. `castToOpaque<number>(1)`
+// 2. default `never` to prohibit unfulfilled type e.g. `castToOpaque(1)`
+// 3. explicit `Transparent` to prevent invalid values e.g. `castToOpaque<OpaqueString>(1)`
+// 4. cast `unknown` first to avoid invalid expression instantiation
+export function castToOpaque<
+  OpaqueType extends Opaque<ValidOpaqueValues, unknown> /* 1. */ = never /* 2. */,
+>(value: Transparent<OpaqueType> /* 3. */) {
+  /* 4. */
   return value as unknown as OpaqueType;
-}
-
-/**
- * A generic helper function that takes an opaquely typed value, and returns the
- * value after widening it to the primitive transparent type.
- */
-export function toTransparent<OpaqueType extends Opaque<ValidOpaqueValues, unknown>>(
-  value: OpaqueType,
-) {
-  return value as unknown as Transparent<OpaqueType>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,33 +1,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-// Predicate types
-// ------------------------------
-
-export type Predicate = (...args: unknown[]) => boolean;
-export type UnaryPredicate<T> = (value: T) => boolean;
-export type GuardedPredicate<T> = (value: any) => value is T;
-
 // Misc. types
 // ------------------------------
+
+export type ErrorLike = { message: string };
 
 export type ObjectEntry<T> = { [K in keyof T]: [K, T[K]] }[keyof T];
 
 export type Nullish = null | undefined;
 
-export type ErrorLike = { message: string };
+export type UnaryPredicate<T> = (value: T) => boolean;
 
 // Opaque types
 // ------------------------------
 
-declare const tag: unique symbol;
-declare type Tagged<Token> = { readonly [tag]: Token };
+declare const OPAQUE_TAG: unique symbol;
+declare type Tagged<Token> = { readonly [OPAQUE_TAG]: Token };
+
 export type ValidOpaqueValues = bigint | number | string | symbol;
 
 /** Create an opaque type. */
-export type Opaque<Type extends ValidOpaqueValues, Token> = Type &
-  Tagged<Token extends void ? never : Token>;
+export type Opaque<Type extends ValidOpaqueValues, Token> = Type & Tagged<Token>;
 
-/** Extract the transparent type from an opaque type. */
+/** @private Extract the transparent type from an opaque type. */
 export type Transparent<OpaqueType extends ValidOpaqueValues> = OpaqueType extends bigint
   ? bigint
   : OpaqueType extends number


### PR DESCRIPTION
Opaques changes:
- remove docs and exports for `Transparent` type generic (still used internally)
- remove `toTransparent` util
- rename ~toOpaque~ to `castToOpaque`
- recommend unique symbols for stronger types

Misc. changes:
- Only support `boolean` condition against `assert()`
- Fix weird edge case with `isDefined()`
- Docs tidy

| Assert changes  | Opaque changes |
| ------------- | ------------- |
| <img width="768" alt="assert changes" src="https://user-images.githubusercontent.com/2730833/170638045-99a718f5-a31d-4e38-925b-bf299f03290f.png">  | <img width="766" alt="image" src="https://user-images.githubusercontent.com/2730833/170638211-18a85c47-3e2b-45e3-a692-285eb2675f3e.png">  |